### PR TITLE
[fix] corenet.go ws error handling

### DIFF
--- a/pkg/corenet/corenet.go
+++ b/pkg/corenet/corenet.go
@@ -64,10 +64,10 @@ func (s *WebSocketServer) Start() error {
 		for {
 			_, message, err := conn.ReadMessage()
 			if err != nil {
-				if websocket.IsUnexpectedCloseError(err, websocket.CloseNormalClosure, websocket.CloseMessage, websocket.CloseMessage) {
-					logging.Info("connection closed", zap.String("remote_address", conn.RemoteAddr().String()))
-				} else if websocket.IsCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
+				if websocket.IsUnexpectedCloseError(err, websocket.CloseMessage, websocket.CloseNormalClosure, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
 					logging.Info("unexpected close error", zap.String("remote_address", conn.RemoteAddr().String()))
+				} else if websocket.IsCloseError(err, websocket.CloseMessage, websocket.CloseNormalClosure, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
+					logging.Info("connection closed", zap.String("remote_address", conn.RemoteAddr().String()))
 				} else {
 					logging.Info("ws message read error", zap.String("remote_address", conn.RemoteAddr().String()))
 				}


### PR DESCRIPTION
websocket.IsUnexpectedCloseError & websocket.IsCloseError expect the expected error classes as inputs.

Also IsUnexpectedCloseError had two duplicate error types

https://pkg.go.dev/github.com/gorilla/websocket#IsUnexpectedCloseError
https://pkg.go.dev/github.com/gorilla/websocket#IsCloseError